### PR TITLE
fix: change LimitOncePerRun to true in default config

### DIFF
--- a/CharonSackControl.lua
+++ b/CharonSackControl.lua
@@ -3,7 +3,7 @@ ModUtil.RegisterMod("CharonSackControl")
 local config = {
     Enabled = true,
     SpawnSack = true,
-    LimitOncePerRun = false,
+    LimitOncePerRun = true,
 }
 CharonSackControl.config = config
 


### PR DESCRIPTION
To a runner, getting 3 Loyalty Cards seems like a bug, even if it's just an incorrect config setting.

Fixes: #1